### PR TITLE
Add optional campaignColour to PaidContentInformation

### DIFF
--- a/src/main/thrift/tag.thrift
+++ b/src/main/thrift/tag.thrift
@@ -91,6 +91,8 @@ struct TrackingInformation {
 struct PaidContentInformation {
     /** The sub type that this paid content is */
     1: required string paidContentType;
+    /** A custom colour used by the campaign in hex format e.g. #FF00FF */
+    2: optional string campaignColour;
 }
 
 struct Reference {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.1"
+version in ThisBuild := "0.6.2"


### PR DESCRIPTION
Small non-breaking change to model to allow campaign colour to be passed with PaidContentInformation
