### PR TITLE
Include new field for podcast type

### DIFF
--- a/src/main/thrift/tag.thrift
+++ b/src/main/thrift/tag.thrift
@@ -55,6 +55,8 @@ struct PodcastMetadata {
     /** iTunes category **/
     9: optional list<PodcastCategory> categories
 
+    10: optional string podcastType
+
 }
 
 struct ContributorInformation {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.0"
+version in ThisBuild := "1.1.1"


### PR DESCRIPTION
In iOS 11 a feature was added to display podcast episodes according to the corresponding podcast type (`episodic` or `serial`). This model update includes this as an optional field.