### PR TITLE
Add contributor's firstName and lastName to model

### DIFF
--- a/src/main/thrift/tag.thrift
+++ b/src/main/thrift/tag.thrift
@@ -75,6 +75,12 @@ struct ContributorInformation {
     /** Contact Email for contributors */
     5: optional string contactEmail;
 
+    /** The contributor's first name used for indexing **/
+    6: optional string  firstName;
+
+    /** The contributor's last name used for indexing **/
+    7: optional string lastName;
+
 }
 
 struct PublicationInformation {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.0"
+version in ThisBuild := "2.1.0"


### PR DESCRIPTION
Adds a `firstName` and `lastName` fields to the model. These are used for ES indexing by CAPI.