### PR TITLE
Podcast tags: Add link for Google Podcast url

### DIFF
--- a/src/main/thrift/tag.thrift
+++ b/src/main/thrift/tag.thrift
@@ -58,6 +58,9 @@ struct PodcastMetadata {
 
     10: optional string podcastType
 
+    /** The Google Podcasts url for the podcast **/
+    11: optional string googlePodcastsUrl
+
 }
 
 struct ContributorInformation {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.2.0"
+version in ThisBuild := "2.2.1"


### PR DESCRIPTION
We want to send through a url for Google Podcasts as well as iTunes.

