### PR TITLE
Add optional football crest in tag

### DIFF
--- a/src/main/thrift/tag.thrift
+++ b/src/main/thrift/tag.thrift
@@ -207,4 +207,7 @@ struct Tag {
 
     /** Any campaigninformation associated with this tag */
     28: optional CampaignInformation campaignInformation;
+
+    /** Football crest image */
+    29: optional image.Image footballCrest;
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.2.2"
+version in ThisBuild := "2.3.0"


### PR DESCRIPTION
First part of a small project to enable football crest assets to be setup in tag manager and retrieved by users in an optimised way. This introduces a new field to the thrift schema for the football crest image, as discussed with @currysoup and @mchv .