### PR TITLE
Add ad blocking level enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the Thrift schema required for interaction with [guardian/tagmanager](https://github.com/guardian/tagmanager).
 
-#Downloading
+# Downloading
 To download you should be able to simply add a dependency similar to the following (with your desired version):
 
 `"com.gu" %% "tags-thrift-schema" % "0.6.3"`

--- a/src/main/thrift/tag.thrift
+++ b/src/main/thrift/tag.thrift
@@ -20,10 +20,16 @@ enum TagType {
     CAMPAIGN = 11
 }
 
+enum AdBlockingLevel {
+    NONE = 0,
+    SUGGEST = 1,
+    FORCE = 2
+}
+
 struct PodcastCategory {
     /** The iTunes main category  **/
     1: required string main
-    
+
     /** The iTunes sub category  **/
     2: optional string sub
 }
@@ -52,7 +58,7 @@ struct PodcastMetadata {
 
     /** iTunes podcast image **/
     8: optional image.Image image
-    
+
     /** iTunes category **/
     9: optional list<PodcastCategory> categories
 
@@ -210,4 +216,7 @@ struct Tag {
 
     /** Football crest image */
     29: optional image.Image footballCrest;
+
+    /** Ad blocking level used to block ads when a tag is applied to content */
+    30: optional AdBlockingLevel adBlockingLevel;
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.3.0"
+version in ThisBuild := "2.4.0"


### PR DESCRIPTION
Sadly we need to include internal-only fields in our thrift schema because of the way the tag caching works. When we push an update to CAPI, other tag manager nodes read off the same stream to keep the caches approximately consistent.

Will just be ignored by porter.