### PR TITLE
Add new event type for tag updates which fan-out to content updates

### DIFF
--- a/src/main/thrift/tagEvent.thrift
+++ b/src/main/thrift/tagEvent.thrift
@@ -4,7 +4,8 @@ namespace scala com.gu.tagmanagement
 
 enum EventType {
     UPDATE = 0,
-    DELETE = 1
+    DELETE = 1,
+    FANOUTUPDATE = 2
 }
 
 struct TagEvent {


### PR DESCRIPTION
Currently tag updates/removals trickle down into N content updates, all managed via tagmanager and perhaps something else behind the scenes. This is problematic for several reasons:

1. for each article, the whole article content has to be pulled from the repository and wired on the kinesis stream
2. ... which has limited capacity anyway, and it often caused problems in the past
3. when Porter receives a content update, it has no way of knowing whether that update has been triggered by a bona fide change in the article, or an update to one of its tags: therefore, it cannot make an informed decision whether to prioritise that update or not. Admittedly, these updates are much less important than changes to the content of the article.

With this change, 1 and 2 can entirely go away. In Porter, when an `FANOUTUPDATE` comes in, we can handle it as a partial reindex, i.e. stream the list of content IDs into bulk updates that will automatically be assigned [a lower priority](https://github.com/guardian/content-api/pull/2220). The same treatment can be done for `DELETE` events, which it isn't at the moment 🤔 