### PR TITLE
Add Pocket Casts url for podcasts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ project/boot/
 
 .idea/
 .idea_modules/
+.metals/
+.vscode/
 
 node_modules/
 

--- a/src/main/thrift/tag.thrift
+++ b/src/main/thrift/tag.thrift
@@ -71,6 +71,9 @@ struct PodcastMetadata {
 
     /** Podcast ID provided by Acast, used to customise the stitching process in Acast Flex */
     13: optional string acastId
+
+    /** The Pocket Casts url for the podcast **/
+    14: optional string pocketCastsUrl
 }
 
 struct ContributorInformation {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.8.1"
+version in ThisBuild := "2.8.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.8.2-SNAPSHOT"
+ThisBuild / version := "2.8.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.8.1-SNAPSHOT"
+version in ThisBuild := "2.8.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.8.1-SNAPSHOT"
+ThisBuild / version := "2.8.2-SNAPSHOT"


### PR DESCRIPTION
## What does this change?
Adds a `pocketCastsUrl` to tag.thrift as part of Pocket Casts work done by the MSS team.

## Why?
MSS team are looking to provide Pocket Casts URL for podcast cards in MAPI so that the native app can allow users to open podcast with the Pocket Casts app directly.
