### PR TITLE
Adopt GHA Scala Library Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    permissions:
+      contents: write
+    secrets:
+      AUTOMATED_MAVEN_RELEASE_PGP_SECRET: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
+      AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,7 @@ on:
 jobs:
   release:
     uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
-    permissions:
-      contents: write
+    permissions: { contents: write, pull-requests: write }
     secrets:
       AUTOMATED_MAVEN_RELEASE_PGP_SECRET: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
       AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tags-thrift-schema
+# tags-thrift-schema [![Release](https://github.com/guardian/tags-thrift-schema/actions/workflows/release.yml/badge.svg)](https://github.com/guardian/tags-thrift-schema/actions/workflows/release.yml)
 
 This repository contains the Thrift schema required for interaction with [guardian/tagmanager](https://github.com/guardian/tagmanager).
 
@@ -14,16 +14,9 @@ If you need to try out your changes with consumer applications (e.g. `tagmanager
 - Run `+publishLocal` in sbt (note the `+` makes it cross-compile, e.g. `tagmanager` consumes the 2.11 version)
 - Update the version in the consumer application(s) (e.g. https://github.com/guardian/tagmanager/blob/e47465cbbcdf9e3d3312c5c779eb52fe0676ce4a/build.sbt#L29) using the `-SNAPSHOT` version.
 
-### Publishing a new version
+## Building a release
 
-1. Follow the instructions for [publishing a new version to Maven Central via Sonatype](https://docs.google.com/document/d/1rNXjoZDqZMsQblOVXPAIIOMWuwUKe3KzTCttuqS7AcY/edit#).
-   This will include (if not already completed for another project):
-    - Creating and publishing a PGP key
-    - Setting up an account on Sonatype and having it added to the `com.gu` group
-    - Storing your Sonatype credentials in your global sbt configuration
-2. Ensure you're on the branch which holds the changes you're ready to release and that these changes have been approved & tested with the application(s) which use this library (using the `-SNAPSHOT` version).
-3. Ensure the project still builds with `sbt compile`
-4. Run `sbt release`. You will be prompted for a 'release version' – which you should set following semantic versioning as either a patch,
-   minor or major version bump. You will also be prompted for a 'next version' – which should be a patch version ahead of your release version
-   and end `-SNAPSHOT`. `version.sbt` will be updated to reflect this 'next version'.
-
+This project uses the [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow)
+to release to Maven Central. To release a new version, execute the
+[Release](https://github.com/guardian/tags-thrift-schema/actions/workflows/release.yml)
+workflow in the Actions tab on GitHub.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@ If you need to try out your changes with consumer applications (e.g. `tagmanager
 - Run `+publishLocal` in sbt (note the `+` makes it cross-compile, e.g. `tagmanager` consumes the 2.11 version)
 - Update the version in the consumer application(s) (e.g. https://github.com/guardian/tagmanager/blob/e47465cbbcdf9e3d3312c5c779eb52fe0676ce4a/build.sbt#L29) using the `-SNAPSHOT` version.
 
-## Building a release
+# Publishing a new release
 
-This project uses the [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow)
-to release to Maven Central. To release a new version, execute the
-[Release](https://github.com/guardian/tags-thrift-schema/actions/workflows/release.yml)
-workflow in the Actions tab on GitHub.
+This repo uses [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow)
+to automate publishing releases (both full & preview releases) - see
+[**Making a Release**](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/making-a-release.md).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# tags-thrift-schema [![Release](https://github.com/guardian/tags-thrift-schema/actions/workflows/release.yml/badge.svg)](https://github.com/guardian/tags-thrift-schema/actions/workflows/release.yml)
+# tags-thrift-schema
+[![tags-thrift-schema Scala version support](https://index.scala-lang.org/guardian/tags-thrift-schema/tags-thrift-schema/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/guardian/tags-thrift-schema/tags-thrift-schema)
+[![Release](https://github.com/guardian/tags-thrift-schema/actions/workflows/release.yml/badge.svg)](https://github.com/guardian/tags-thrift-schema/actions/workflows/release.yml)
 
 This repository contains the Thrift schema required for interaction with [guardian/tagmanager](https://github.com/guardian/tagmanager).
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ releaseCrossBuild := true
 
 resolvers += Resolver.jcenterRepo
 
-licenses += ("Apache-2.0", url("https://github.com/guardian/tags-thrift-schema/blob/main/LICENSE"))
+licenses := Seq(License.Apache2)
 releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value
 
 releaseProcess := Seq[ReleaseStep](

--- a/build.sbt
+++ b/build.sbt
@@ -27,11 +27,8 @@ releaseProcess := Seq[ReleaseStep](
   runClean,
   runTest,
   setReleaseVersion,
-  publishArtifacts,
-  releaseStepCommand("sonatypeReleaseAll"),
   commitReleaseVersion,
   tagRelease,
   setNextVersion,
-  commitNextVersion,
-  pushChanges
+  commitNextVersion
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,8 @@
 import ReleaseTransformations._
+import sbtversionpolicy.withsbtrelease.ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease
 
 name := "tags-thrift-schema"
 organization := "com.gu"
-
-scmInfo := Some(ScmInfo(url("https://github.com/guardian/tags-thrift-schema"), "scm:git@github.com:guardian/tags-thrift-schema"))
-homepage := scmInfo.value.map(_.browseUrl)
-developers := List(Developer(id = "guardian", name = "Guardian", email = null, url = url("https://github.com/guardian")))
-
 
 libraryDependencies ++= Seq(
   "org.apache.thrift" % "libthrift" % "0.13.0",
@@ -14,16 +10,17 @@ libraryDependencies ++= Seq(
 )
 
 // Might cross compile more scala versions here depending on who needs this!
-scalaVersion := "2.13.1"
-crossScalaVersions := Seq("2.11.12", "2.12.10", scalaVersion.value)
+scalaVersion := "2.13.11"
+crossScalaVersions := Seq("2.12.18", scalaVersion.value)
+scalacOptions := Seq(
+  "-release:11"
+)
 releaseCrossBuild := true
 
 resolvers += Resolver.jcenterRepo
 
 licenses += ("Apache-2.0", url("https://github.com/guardian/tags-thrift-schema/blob/main/LICENSE"))
-
-releasePublishArtifactsAction := PgpKeys.publishSigned.value
-publishTo := sonatypePublishTo.value
+releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value
 
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,

--- a/build.sbt
+++ b/build.sbt
@@ -17,9 +17,8 @@ scalacOptions := Seq(
 )
 releaseCrossBuild := true
 
-resolvers += Resolver.jcenterRepo
-
 licenses := Seq(License.Apache2)
+
 releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value
 
 releaseProcess := Seq[ReleaseStep](

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.7
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // Plugin to actually build the thrift
 addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "19.11.0")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")


### PR DESCRIPTION
This replaces the old release process which had developers manually running `sbt release` on their own laptops - each developer had to obtain their own PGP key and Sonatype credentials, which was an elaborate & fiddly process.

Now there's a single set of release credentials, available through GitHub Organisation Secrets, like we already have with NPM.

The changes required to adopt the automated workflow:

* No need to set these sbt configuration keys, as they're now taken care of by the workflow:
  * `scmInfo` & `pomExtra`
  * `homepage`
  * `developers`
  * `releasePublishArtifactsAction`
  * `publishTo`
* Remove the publish, release & push steps of sbt-release's `releaseProcess` configuration, because the workflow does those now, and the workflow only wants `sbt release` to create the versioning commits, and tag them appropriately. The workflow does the rest itself.
* Remove `sbt-pgp` plugin because it's no longer used - the workflow does the signing using `gpg` directly.
* Grant this repo access to the GitHub Organisation Secrets containing the Maven Release credentials with guardian/github-secret-access#21

Additionally, we add **automatic version numbering** based on compatibility assessment performed by `sbt-version-policy`:

* Add the `sbt-version-policy` plugin, to allow it to do the compatibility assessment. This also sets the `versionScheme` for this library to `early-semver`, which is the recommended versioning for Scala libraries, and `sbt-version-policy` & correct sbt-eviction-issue-detection pretty much depend on the `versionScheme` being `early-semver`. Thus we also need to switch to using a new semver version number for our library version!
* Add the `releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value` sbt setting, which will intelligently set the release version based on `sbt-version-policy`'s compatibility assessment, thanks to scalacenter/sbt-version-policy#187 .

This change also drops support for Scala 2.11 since it does not seem to support the -release:11 scalac option which is required to ensure that the Java 17 workflow produces Java 11 compatible bytecode.

__NB - PR description liberally copied from https://github.com/guardian/facia-scala-client/pull/299__