### PR TITLE
Update gha-scala-library-release-workflow params

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,5 +8,5 @@ jobs:
     uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
     permissions: { contents: write, pull-requests: write }
     secrets:
-      AUTOMATED_MAVEN_RELEASE_PGP_SECRET: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
-      AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}


### PR DESCRIPTION
These parameters were renamed with
guardian/gha-scala-library-release-workflow@123feef for greater consistency, we name to rename here:

* `AUTOMATED_MAVEN_RELEASE_PGP_SECRET` -> `PGP_PRIVATE_KEY`
* `AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD` -> `SONATYPE_PASSWORD`