### PR TITLE
Add episodic artwork fields to podcast metadata model

### DIFF
--- a/src/main/thrift/tag.thrift
+++ b/src/main/thrift/tag.thrift
@@ -74,6 +74,12 @@ struct PodcastMetadata {
 
     /** The Pocket Casts url for the podcast **/
     14: optional string pocketCastsUrl
+
+    /** Whether or not episodic art should be enabled */
+    15: optional bool episodicArtworkEnabled;
+
+    /** The date from which episodic art should be enabled */
+    16: optional i64 episodicArtworkEnabledFrom;
 }
 
 struct ContributorInformation {

--- a/src/main/thrift/tag.thrift
+++ b/src/main/thrift/tag.thrift
@@ -78,7 +78,7 @@ struct PodcastMetadata {
     /** Whether or not episodic art should be enabled */
     15: optional bool episodicArtworkEnabled;
 
-    /** The date from which episodic art should be enabled */
+    /** The date from which episodic art should be enabled, represented in milliseconds since unix epoch */
     16: optional i64 episodicArtworkEnabledFrom;
 }
 


### PR DESCRIPTION
## What does this change?

As part of our objective to bring episodic artwork controls into our tooling, we need to add two new fields to the podcast metadata model:

- `episodicArtworkEnabled` (boolean)
- `episodicArtworkEnabledFrom` (datetime)

Afterwards, we will update tag manager to read/write them.

## How to test

There are instructions in the accompanying tag manager branch: https://github.com/guardian/tagmanager/pull/558

## How can we measure success?

We can continue the work in tag manager.

## Have we considered potential risks?

Both fields are optional so this is low risk.

## Related PRs

- [tags-thrift-schema](https://github.com/guardian/tags-thrift-schema/pull/48) <- you are here
- [tagmanager](https://github.com/guardian/tagmanager/pull/558) 
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3093) 
- [content-api-models](https://github.com/guardian/content-api-models/pull/261)
- [content-api (Concierge) ](https://github.com/guardian/content-api/pull/3100) 
- [content-api-scala-client](https://github.com/guardian/content-api-scala-client/pull/443)
- [itunes-rss](https://github.com/guardian/itunes-rss/pull/180)