### PR TITLE
Adds an optional keyword type to the Tag model with a KeywordType enum

### DIFF
--- a/src/main/thrift/tag.thrift
+++ b/src/main/thrift/tag.thrift
@@ -20,6 +20,16 @@ enum TagType {
     CAMPAIGN = 11
 }
 
+/** the types of keywords supported */
+enum KeywordType {
+    PERSON = 0,
+    ORGANISATION = 1,
+    EVENT = 2,
+    WORK_OF_ART_OR_PRODUCT = 3,
+    PLACE = 4,
+    OTHER = 5
+}
+
 enum BlockingLevel {
     NONE = 0,
     SUGGEST = 1,
@@ -234,4 +244,7 @@ struct Tag {
 
     /** Blocking level used to block reader revenue asks when a tag is applied to content */
     31: optional BlockingLevel contributionBlockingLevel;
+
+    /** Keyword tags types */
+    32: optional KeywordType keywordType;
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds an optional keyword type to the Tag model with a KeywordType enum

## What does this change?

As part of the work to all keyword tagging in tag manager, we need to extend the Tag model to include an optional keyword type. This is accompanied by a KeywordType enum which is an exhaustive list of all possible keywords.

## How to test
Running tag manager with a snapshot version of this release and verifying that it is able to read/write this field.

## Have we considered potential risks?

The new field is optional so this is low risk.
