### PR TITLE
Add tag deprecated property

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ If you need to try out your changes with consumer applications (e.g. `tagmanager
 - Run `+publishLocal` in sbt (note the `+` makes it cross-compile, e.g. `tagmanager` consumes the 2.11 version)
 - Update the version in the consumer application(s) (e.g. https://github.com/guardian/tagmanager/blob/e47465cbbcdf9e3d3312c5c779eb52fe0676ce4a/build.sbt#L29) using the `-SNAPSHOT` version.
 
+The terminal feedback from `+publishLocal` will include a line confirming the version of the library it has created in your ~/.ivy2/local folder. EG, the local version is "2.8.7-SNAPSHOT":
+
+```
+[info] :: delivering :: com.gu#tags-thrift-schema_2.13;2.8.7-SNAPSHOT :: 2.8.7-SNAPSHOT :: integration :: Thu Apr 09 14:06:23 BST 2026
+```
+
+So the updated dependency in version in the consumer application could be:
+`"com.gu" %% "tags-thrift-schema" % "2.8.7-SNAPSHOT"`
+
 # Publishing a new release
 
 This repo uses [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow)

--- a/src/main/thrift/tag.thrift
+++ b/src/main/thrift/tag.thrift
@@ -248,6 +248,10 @@ struct Tag {
     /** Keyword tags types */
     32: optional KeywordType keywordType;
 
-    /** Used to determine if a tag can be added to content, if true it should not be presented to users in the tooling */
+    /** A tag with deprecated = true should not be used.
+     *
+     * For example, tooling might choose not to allow users to add a deprecated
+     * tag to content.
+     */
     33: optional bool deprecated;
 }

--- a/src/main/thrift/tag.thrift
+++ b/src/main/thrift/tag.thrift
@@ -248,6 +248,6 @@ struct Tag {
     /** Keyword tags types */
     32: optional KeywordType keywordType;
 
-    /** the tag is not presented to users to be added to content in the tooling if deprecated is true */
+    /** Used to determine if a tag can be added to content, if true it should not be presented to users in the tooling */
     33: optional bool deprecated;
 }

--- a/src/main/thrift/tag.thrift
+++ b/src/main/thrift/tag.thrift
@@ -247,4 +247,7 @@ struct Tag {
 
     /** Keyword tags types */
     32: optional KeywordType keywordType;
+
+    /** the tag is not presented to users to be added to content in the tooling if deprecated is true */
+    33: optional bool deprecated;
 }


### PR DESCRIPTION
## What does this change?

Adds an optional Boolean property "deprecated" to Tag.

## How has this change been tested?

tested against a local snapshot on this branch of tag manager: 
https://github.com/guardian/tagmanager/tree/add-deprecated-field--use-thrift-update

## How can we measure success?

See. https://github.com/guardian/workflow/issues/1378 and  https://github.com/guardian/tagmanager/pull/631 for context.

This PR should enable the subscribers to the Tag update stream to model the new  "deprecated"  property

## Have we considered potential risks?

We are modelling this property as optional since it will be undefined for Tags created before the new property is rolled out (IE all of them currently). 
